### PR TITLE
Fixed: Can't start the engine with the Logiteck multipanel

### DIFF
--- a/C152X/SimObjects/Airplanes/Asobo_C152/engines.cfg
+++ b/C152X/SimObjects/Airplanes/Asobo_C152/engines.cfg
@@ -25,7 +25,7 @@ max_indicated_rpm = 3500
 fuel_metering_type = 1 ; 0=Fuel Injected, 1=Gravity Carburetor, 2=Aerobatic Carburetor
 cooling_type = 0 ; 0=Cooling type Air, 1=Cooling type Liquid
 normalized_starter_torque = 0.2 ; Starter torque factor **SG updated was 0.3
-starter_time = 0.55 ; Time the Starter stays active when pressed **SG updated was 1.5
+starter_time = 1.5 ; Time the Starter stays active when pressed
 turbocharged = 0 ; Is it turbocharged? 0=FALSE, 1=TRUE
 max_design_mp = 0 ; Max design manifold pressure, (inHg)
 min_design_mp = 0 ; Min design manifold pressure, (inHg)

--- a/C152X/SimObjects/Airplanes/Asobo_C152/model/Cessna152_interior.XML
+++ b/C152X/SimObjects/Airplanes/Asobo_C152/model/Cessna152_interior.XML
@@ -46,44 +46,42 @@
 	
 	<!-- ELECTRICAL ########################### -->
 	<Component ID="ELECTRICAL">
+		<DefaultTemplateParameters>
+			<SYNC_AVIONICS_TO_BATTERY_STATE>
+				(A:ELECTRICAL MASTER BATTERY:1, Bool) (&gt;O:_AvionicsShouldBeOn)
+				1 (&gt;A:BUS LOOKUP INDEX, Number)
+				(O:_AvionicsShouldBeOn) (A:BUS CONNECTION ON:2, Bool) != if{
+					2 1 (&gt;K:2:ELECTRICAL_BUS_TO_BUS_CONNECTION_TOGGLE)
+				}
+				(O:_AvionicsShouldBeOn) (A:CIRCUIT SWITCH ON:17, Bool) != if{
+					17 (&gt;K:ELECTRICAL_CIRCUIT_TOGGLE)
+				}
+			</SYNC_AVIONICS_TO_BATTERY_STATE>
+		</DefaultTemplateParameters>
 		<UseTemplate Name="ASOBO_ELECTRICAL_Switch_Magneto_Template">
 			<ANIM_NAME>ELECTRICAL_Switch_Magneto</ANIM_NAME>
 			<NODE_ID>ELECTRICAL_Switch_Magneto</NODE_ID>
 			<SWITCH_DIRECTION>Horizontal</SWITCH_DIRECTION>
-			<NORMALIZED_TIME>0.75</NORMALIZED_TIME>
-			<DIRECTION>Forward</DIRECTION>
 			<INDEX_OFF>0</INDEX_OFF>
 			<INDEX_RIGHT>1</INDEX_RIGHT>
 			<INDEX_LEFT>2</INDEX_LEFT>
 			<INDEX_BOTH>3</INDEX_BOTH>
 			<ARROW_TYPE>Curved</ARROW_TYPE>
+			<STATE_MAX_TIMER>1.5</STATE_MAX_TIMER>
 			<USE_STARTER/>
-			<!-- Max time in START pos (any input except mouse), when using mouse will stay for this time0 -->
-			<STATE_MAX_TIMER>3</STATE_MAX_TIMER>
-			<ANIMREF_ID>0</ANIMREF_ID>
-			<ANIMCURSOR_DIR>1</ANIMCURSOR_DIR>
-			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.MAGNETO_START_SWITCH_OFF</ANIMTIP_0>
-			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.MAGNETO_START_SWITCH_R</ANIMTIP_1>
-			<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.MAGNETO_START_SWITCH_L</ANIMTIP_2>
-			<ANIMTIP_3>TT:COCKPIT.TOOLTIPS.MAGNETO_START_SWITCH_BOTH</ANIMTIP_3>
-			<ANIMTIP_4>TT:COCKPIT.TOOLTIPS.MAGNETO_START_SWITCH_START</ANIMTIP_4>			
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_ELECTRICAL_Switch_Alternator_Template">
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_ELECTRICAL_Switch_Battery_Master_Template">
 			<!-- This battery switch also controls avionics -->
 			<ON_TOGGLE_MASTER_BATTERY>
-				(A:ELECTRICAL MASTER BATTERY:1, Bool) (A:AVIONICS MASTER SWITCH, Bool) != if{
-					(&gt;K:TOGGLE_AVIONICS_MASTER)
-				}
+				#SYNC_AVIONICS_TO_BATTERY_STATE#
 			</ON_TOGGLE_MASTER_BATTERY>
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_GT_Update">
 			<FREQUENCY>5</FREQUENCY>
 			<UPDATE_CODE>
-				(A:ELECTRICAL MASTER BATTERY:1, Bool) (A:AVIONICS MASTER SWITCH, Bool) != if{
-					(&gt;K:TOGGLE_AVIONICS_MASTER)
-				}
+				#SYNC_AVIONICS_TO_BATTERY_STATE#
 			</UPDATE_CODE>
 		</UseTemplate>
 	</Component>


### PR DESCRIPTION
Issue: The problem that I cannot start the Engine when I'm useing logiteck multipanel. When crank the "Key" on the Yoke and hold it on "start" the key in the Simulator will jump back on "both" to fast so the Engine will not start.

Solution:
Updated: "Component ID="ELECTRICAL" in Cessna152_interior.xml file to the same as origin Cessna 152.
Updated: "starter_time" to previous value in engines.cfg file