### PR TITLE
Fixed: Cabin heat/air switch can be set from 0 to 100%

### DIFF
--- a/C152X/SimObjects/Airplanes/Asobo_C152/model/Cessna152_interior.XML
+++ b/C152X/SimObjects/Airplanes/Asobo_C152/model/Cessna152_interior.XML
@@ -425,16 +425,16 @@
 	
 	<!-- PASSENGERS ########################### -->
 	<Component ID="PASSENGERS">
-		<UseTemplate Name="ASOBO_PASSENGER_Switch_Cabin_Air_Template">
-			<ANIMREF_ID>0</ANIMREF_ID>
-			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.CABIN_AIR_2STATES_PUSHED</ANIMTIP_0>
-			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.CABIN_AIR_2STATES_PULLED</ANIMTIP_1>
+		<Parameters Type="Override">
+			<INVERT_IM_DRAG_INPUT_SCALAR>True</INVERT_IM_DRAG_INPUT_SCALAR>
+		</Parameters>
+		<UseTemplate Name="ASOBO_PASSENGER_Lever_Cabin_Air_Template">
+			<NODE_ID>PASSENGER_Switch_Cabin_Air_1</NODE_ID>
+			<ANIM_NAME>PASSENGER_Switch_Cabin_Air_1</ANIM_NAME>
 		</UseTemplate>
-		
-		<UseTemplate Name="ASOBO_PASSENGER_Switch_Cabin_Heat_Template">
-			<TOOLTIPID>DOD</TOOLTIPID>
-			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.CABIN_HEAT_2STATES_PUSHED</ANIMTIP_0>
-			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.CABIN_HEAT_2STATES_PULLED</ANIMTIP_1>
+		<UseTemplate Name="ASOBO_PASSENGER_Lever_Cabin_Heat_Template">
+			<NODE_ID>PASSENGER_Switch_Cabin_Heat_1</NODE_ID>
+			<ANIM_NAME>PASSENGER_Switch_Cabin_Heat_1</ANIM_NAME>
 		</UseTemplate>
 	</Component>
 	


### PR DESCRIPTION
Issue:
The heat/air switch in the cab works like an on/off switch.

Solution:
Component ID="PASSENGERS" block has been updated from the original model